### PR TITLE
Use the node version as part of the cache

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,9 +29,10 @@ jobs:
         path: |
           ${{ steps.yarn-cache.outputs.dir }}
           node_modules
-        key: ${{ runner.os }}-node-${{ matrix.node_version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/.node-version') }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ matrix.node_version }}
+          ${{ runner.os }}-node
+          ${{ runner.os }}-node-${{ hashFiles('**/.node-version') }}
 
     - name: Install dependencies
       run: yarn install --pure-lockfile


### PR DESCRIPTION
Hopefully improves testing speed